### PR TITLE
修正并发情况下锁的正确性

### DIFF
--- a/sync_lock.go
+++ b/sync_lock.go
@@ -162,6 +162,28 @@ func (repo *Repo) lockCloud0(currentDeviceID string) (err error) {
 		}
 
 		err = ErrLockCloudFailed
+		return
+	}
+	data, err = repo.cloud.DownloadObject(lockSyncKey)
+	if err != nil {
+		// 二次确认时，如果锁文件已经被删除了，说明其他设备已经拿到锁后释放锁了，此时可以留待下一次尝试
+		if errors.Is(err, cloud.ErrCloudObjectNotFound) {
+			return ErrCloudLocked
+		}
+		logging.LogErrorf("get lock sync failed: %s", err)
+		return err
+	}
+	content = make(map[string]any)
+	err = gulu.JSON.UnmarshalJSON(data, &content)
+	if err != nil {
+		// 解码失败可能是用户手动修改了该文件，需要删除后重新锁定
+		logging.LogErrorf("unmarshal lock sync failed: %s", err)
+		repo.cloud.RemoveObject(lockSyncKey)
+		return ErrCloudLocked
+	}
+	deviceID := content["deviceID"].(string)
+	if deviceID != currentDeviceID {
+		return ErrCloudLocked
 	}
 	return
 }


### PR DESCRIPTION
此处可能会有问题
有一种情况：两个实例同时下载锁文件，发现锁不存在，然后两个实例均进行锁文件上传，此时实际上两个实例均获取到了锁，但预期只能有一个获取到锁