### PR TITLE
Support cloud storage purge for local filesystem sync

### DIFF
--- a/cloud/local.go
+++ b/cloud/local.go
@@ -142,18 +142,50 @@ func (local *Local) RemoveObject(filePath string) (err error) {
 
 func (local *Local) ListObjects(pathPrefix string) (objects map[string]*entity.ObjectInfo, err error) {
 	objects = map[string]*entity.ObjectInfo{}
-	pathPrefix = path.Join(local.getCurrentRepoDirPath(), pathPrefix)
-	entries, err := os.ReadDir(pathPrefix)
+	// objects/ 为两级目录 objects/XX/<id>，需递归列出以匹配 PurgeCloud 与 S3 的路径格式
+	isObjectsDir := strings.HasPrefix(pathPrefix, "objects")
+	absPathPrefix := path.Join(local.getCurrentRepoDirPath(), pathPrefix)
+	entries, err := os.ReadDir(absPathPrefix)
 	if err != nil {
-		logging.LogErrorf("list objects [%s] failed: %s", pathPrefix, err)
+		if os.IsNotExist(err) {
+			return
+		}
+		logging.LogErrorf("list objects [%s] failed: %s", absPathPrefix, err)
 		return
 	}
 
 	for _, entry := range entries {
+		if isObjectsDir && entry.IsDir() {
+			subDir := path.Join(absPathPrefix, entry.Name())
+			subEntries, subErr := os.ReadDir(subDir)
+			if subErr != nil {
+				err = subErr
+				logging.LogErrorf("list objects [%s] failed: %s", subDir, err)
+				return
+			}
+			for _, subEntry := range subEntries {
+				if subEntry.IsDir() {
+					continue
+				}
+				subInfo, subInfoErr := subEntry.Info()
+				if subInfoErr != nil {
+					err = subInfoErr
+					logging.LogErrorf("get object [%s] info failed: %s", path.Join(subDir, subEntry.Name()), err)
+					return
+				}
+				relPath := path.Join(entry.Name(), subEntry.Name())
+				objects[relPath] = &entity.ObjectInfo{
+					Path: relPath,
+					Size: subInfo.Size(),
+				}
+			}
+			continue
+		}
+
 		entryInfo, infoErr := entry.Info()
 		if infoErr != nil {
 			err = infoErr
-			logging.LogErrorf("get object [%s] info failed: %s", path.Join(pathPrefix, entry.Name()), err)
+			logging.LogErrorf("get object [%s] info failed: %s", path.Join(absPathPrefix, entry.Name()), err)
 			return
 		}
 


### PR DESCRIPTION
https://github.com/siyuan-note/siyuan/issues/17752

我试了一下把数据快照上传到本地文件系统，然后清理时会报错：`清理数据仓库失败：remove D:/Admin/Downloads/local/siyuan-test-8s7g0a/objects/7f: The directory is not empty. v3.6.5`，所以让 AI 修了一下，我没看过逻辑，仅供参考。

---

````
**问题出在 dejavu 的 `cloud.Local.ListObjects`，不是思源 UI，也不是 `PurgeCloud` 的整体逻辑本身。**

## 数据是怎么存的

数据仓库里的对象按 **两级路径** 存放（与 S3 一致）：

```text
objects/
  └─ 7f/                    ← 哈希前 2 位作子目录
       └─ abc123...         ← 完整对象 ID 作文件名
```

本机数据仓库清理（`Store.Purge`）会正确遍历 `objects/XX/` 下的文件。

## 清理云端时在做什么

点「清理云端存储」会走 `Repo.PurgeCloud()`，大致步骤：

1. `cloud.ListObjects("objects/")` 列出所有对象  
2. 根据 `refs` 判断哪些索引、对象仍被引用  
3. 对未引用的路径调用 `cloud.RemoveObject(...)` 删除  

S3 的 `ListObjects` 会列出完整 key（如 `7f/abc123...`），所以能删对**单个文件**。

## 原来的 bug

`Local.ListObjects` **只读了 `objects/` 下一层**：

```143:165:D:\CodeProjects\dejavu\cloud\local.go
// 修复前：只把 entry.Name() 当作 filePath，得到的是 "7f"、"ab" 等目录名
```

于是 `PurgeCloud` 里会把 `7f` 当成对象 ID（只有 2 个字符），再拼路径时变成 `objects/7f`，最后对**整个目录**执行 `os.Remove`：

```127:129:D:\CodeProjects\dejavu\cloud\local.go
func (local *Local) RemoveObject(filePath string) (err error) {
	key := path.Join(local.getCurrentRepoDirPath(), filePath)
	err = os.Remove(key)  // 目录非空 → Windows 报错
```

所以你看到的是：

> `remove .../objects/7f: The directory is not empty`

本质是：**列清单列错了（列成子目录名），删除时就去删目录，而不是删目录里的文件。**

## 修复做了什么

在 `objects/` 前缀下多走一层，返回 `7f/完整哈希` 这种路径，与 S3、`Store.Purge` 的语义一致，这样 `RemoveObject` 删的是具体文件。

---

**补充：** WebDAV 的 `ListObjects` 若也只列一层，在 WebDAV 上做「清理云端存储」可能遇到同类问题；本地文件系统因为直接用 `os.ReadDir`，这个问题最明显。你这次验证通过，说明本地路径已对齐正确行为。
````